### PR TITLE
Updated to new version of pylexibank.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Conceptlist in Concepticon: [Bowern-2017-348](http://concepticon.clld.org/contri
 
 
 [![Build Status](https://travis-ci.org/lexibank/bowernpny.svg?branch=master)](https://travis-ci.org/lexibank/bowernpny)
-![Glottolog: 100%](https://img.shields.io/badge/Glottolog-100%25-brightgreen.svg "Glottolog: 100%")
-![Concepticon: 100%](https://img.shields.io/badge/Concepticon-100%25-brightgreen.svg "Concepticon: 100%")
+![Glottolog: 93%](https://img.shields.io/badge/Glottolog-93%25-green.svg "Glottolog: 93%")
+![Concepticon: 99%](https://img.shields.io/badge/Concepticon-99%25-green.svg "Concepticon: 99%")
 ![Source: 100%](https://img.shields.io/badge/Source-100%25-brightgreen.svg "Source: 100%")
 ![BIPA: 99%](https://img.shields.io/badge/BIPA-99%25-brightgreen.svg "BIPA: 99%")
 ![CLTS SoundClass: 99%](https://img.shields.io/badge/CLTS%20SoundClass-99%25-brightgreen.svg "CLTS SoundClass: 99%")

--- a/cldf/cldf-metadata.json
+++ b/cldf/cldf-metadata.json
@@ -20,6 +20,13 @@
                 "glottolog_version": "pyglottolog-1.2.1-60-gf46bb64",
                 "concepticon_version": "pyconcepticon-1.4.0-39-g121e0c7"
             }
+        },
+        {
+            "dc:title": "environment",
+            "properties": {
+                "glottolog_version": "pyglottolog-1.2.1-60-gf46bb64",
+                "concepticon_version": "pyconcepticon-1.4.0-39-g121e0c7"
+            }
         }
     ],
     "tables": [

--- a/cldf/cldf-metadata.json
+++ b/cldf/cldf-metadata.json
@@ -17,8 +17,8 @@
         {
             "dc:title": "environment",
             "properties": {
-                "glottolog_version": "v3.3.2",
-                "concepticon_version": "pyconcepticon-1.4.0-10-g1d57531"
+                "glottolog_version": "pyglottolog-1.2.1-60-gf46bb64",
+                "concepticon_version": "pyconcepticon-1.4.0-39-g121e0c7"
             }
         }
     ],
@@ -156,10 +156,6 @@
                     {
                         "datatype": "string",
                         "name": "Family"
-                    },
-                    {
-                        "datatype": "string",
-                        "name": "Glottolog_name"
                     }
                 ],
                 "primaryKey": [

--- a/cldf/languages.csv
+++ b/cldf/languages.csv
@@ -1,191 +1,191 @@
-ID,Name,Glottocode,Glottolog_Name,ISO639P3code,Macroarea,Family,Glottolog_name
-adnyamathanha,Adnyamathanha,adny1235,,,,,Adnyamathanha
-aghutharrnggala,Aghu-Tharrnggala,aghu1254,,,,,Aghu Tharnggalu
-alyawarr,Alyawarr,alya1239,,,,,Alyawarr
-antekerrepenhe,Antekerrepenhe,ande1247,,,,,Andegerebinha
-arabana,Arabana,arab1267,,,,,Arabana
-awabakal,Awabakal,awab1243,,,,,Awabakal
-badimaya,Badimaya,badi1246,,,,,Badimaya
-badjiri,Badjiri,badj1244,,,,,Badjiri
-bandjalang,Bandjalang,band1339,,,,,Yugambeh-Bandjalang
-batyala,Batyala,kabi1260,,,,,Kabikabi
-bidyaragungabula,Bidyara-Gungabula,sout2765,,,,,Southern Maric
-bilinarra,Bilinarra,bili1250,,,,,Bilinara
-biri,Biri,biri1256,,,,,Biri
-birrpayi,Birrpayi,birr1241,,,,,Birrpayi
-bularnu,Bularnu,bula1255,,,,,Bularnu
-bunganditj,Bunganditj,bung1264,,,,,Bunganditj
-colac,Colac,cola1237,,,,,Colac
-darkinyung,Darkinyung,hawk1239,,,,,Hawkesbury
-dhangu,Dhangu,dhan1270,,,,,Dhangu
-dharawal,Dharawal,thur1254,,,,,Thurawal
-dharuk,Dharuk,sydn1236,,,,,Sydney
-dharumbal,Dharumbal,dhar1248,,,,,Dharumbal
-dhayyi,Dhayyi,dayi1244,,,,,Dayi
-dhudhuroa,Dhudhuroa,dhud1236,,,,,Dhudhuroa
-dhurga,Dhurga,dhur1239,,,,,Dhurga
-dhuwal,Dhuwal,dhuw1249,,,,,Dhuwal
-dhuwala,Dhuwala,,,,,,
-diyari,Diyari,dier1241,,,,,Dieri
-djabugay,Djabugay,dyaa1242,,,,,Dyaabugay
-djambarrpuyngu,Djambarrpuyngu,djam1256,,,,,Djambarrpuyngu
-djapu,Djapu,djap1238,,,,,Djapu
-djinang,Djinang,djin1253,,,,,Djinang
-durubul,Durubul,,,,,,
-duungidjawu,Duungidjawu,duun1241,,,,,Duungidjawu
-dyirbal,Dyirbal,dyir1250,,,,,Dyirbal
-flindersisland,Flinders Island,flin1247,,,,,Flinders Island
-gairi,Gairi,wadj1255,,,,,Wadjigu
-gamilaraay,Gamilaraay,gami1243,,,,,Gamilaraay
-gangulu,Gangulu,gang1268,,,,,Gangulu
-garlali,Garlali,kala1380,,,,,Kalali
-goorenggooreng,Gooreng Gooreng,gure1255,,,,,Gureng Gureng
-gudjal,Gudjal,gudj1237,,,,,Gudjal
-gumatj,Gumatj,guma1253,,,,,Gumatj
-gumbaynggir,Gumbaynggir,kumb1268,,,,,Kumbainggar
-gunditjmara,Gunditjmara,gund1249,,,,,Gunditjmara
-gundungurra,Gundungurra,nort2760,,,,,Northern Inland Yui
-gunggari,Gunggari,kung1258,,,,,Kunggari
-gunya,Gunya,guny1241,,,,,Gunya
-gupapuyngu,Gupapuyngu,gupa1247,,,,,Gupapuyngu
-gurindji,Gurindji,guri1247,,,,,Gurindji
-guuguyimidhirr,Guugu-Yimidhirr,gugu1255,,,,,Guugu Yimidhirr
-guwa,Guwa,guwa1242,,,,,Guwa
-guyani,Guyani,guya1249,,,,,Guyani
-iyora,Iyora,sydn1236,,,,,Sydney
-jaru,Jaru,jaru1254,,,,,Jaru
-jarumcc,Jaru-McC,,,,,,
-jiwarli,Jiwarli,djiw1241,,,,,Djiwarli
-jiwarliny,Jiwarliny,walm1241,,,,,Walmajarri
-kaanju,Kaanju,kanj1260,,,,,Kanju
-kalkatungu,Kalkatungu,kalk1246,,,,,Kalkutung
-kamilaroi,Kamilaroi,gami1243,,,,,Gamilaraay
-karajarri,Karajarri,kara1476,,,,,Karadjeri
-karajarrinw,KarajarriNW,,,,,,
-kariyarra,Kariyarra,kari1304,,,,,Kariyarra
-karree,Karree,,,,,,
-kartujarra,Kartujarra,kart1247,,,,,Kartujarra
-karuwali,Karuwali,karr1236,,,,,Karruwali
-katthang,Katthang,gath1234,,,,,Gathang
-kaurna,Kaurna,kaur1267,,,,,Kaurna
-keramin,Keramin,nort2756,,,,,Northern Sunraysia
-kugunganhcara,Kugu Nganhcara,kuku1280,,,,,Kuku-Uwan
-kukatj,Kukatj,guga1239,,,,,Gugadj
-kukatja,Kukatja,kuka1246,,,,,Kukatja
-kukuyalanji,Kuku Yalanji,kuku1273,,,,,Kuku-Yalanji
-kukuyalanjicurr,KukuYalanjiCurr,,,,,,
-kungadutyi,Kungadutyi,,,,,,
-kungkari,Kungkari,kuun1236,,,,,Kuungkari of Barcoo River
-kurnu,Kurnu,kula1275,,,,,Kula (Australia)
-kurrama,Kurrama,kurr1243,,,,,Kurrama
-kurtjar,Kurtjar,gurd1238,,,,,Gurdjar
-kuukuyau,Kuuku-Ya’u,kuuk1238,,,,,Kuuku-Ya'u
-linngithigh,Linngithigh,leni1238,,,,,Leningitij
-mabuiag,Mabuiag,kala1377,,,,,Kala Lagaw Ya
-malgana,Malgana,malg1242,,,,,Malgana
-malngin,Malngin,maln1239,,,,,Malngin
-malyangapa,Malyangapa,maly1234,,,,,Malyangapa
-mangalamck,MangalaMcK,,,,,,
-mangalanw,MangalaNW,,,,,,
-margany,Margany,marg1253,,,,,Margany
-martuwangka,Martu Wangka,mart1256,,,,,Martu Wangka
-maryriverandbunyabunyacountry,Mary River and Bunya Bunya Country,,,,,,
-mathimathi,Mathi-Mathi,madh1244,,,,,Madhi Madhi
-mayikulan,Mayi-Kulan,mayi1236,,,,,Mayi-Kulan
-mayikutuna,Mayi-Kutuna,maya1280,,,,,Mayaguduna
-mayithakurti,Mayi-Thakurti,mayi1234,,,,,Mayi-Thakurti
-mayiyapi,Mayi-Yapi,mayi1235,,,,,Mayi-Yapi
-mbabaram,Mbabaram,mbab1239,,,,,Mbabaram
-mbakwithi,Mbakwithi,angu1242,,,,,Anguthimri
-minjungbal,Minjungbal,minj1242,,,,,Minjungbal
-mirniny,Mirniny,kala1379,,,,,Kalarko
-mithaka,Mithaka,mith1236,,,,,Mithaka
-mountfreelingdiyari,Mount Freeling Diyari,,,,,,
-mudburra,Mudburra,mudb1240,,,,,Mudburra
-mudburramcc,Mudburra-McC,,,,,,
-muruwari,Muruwari,muru1266,,,,,Muruwari
-narrungga,Narrungga,naru1238,,,,,Narungga
-nggoimwoi,Ng'goi Mwoi,,,,,,
-ngaanyatjarra,Ngaanyatjarra,ngaa1240,,,,,Ngaanyatjarra
-ngadjumaya,Ngadjumaya,ngad1258,,,,,Ngadjunmaya
-ngadjuri,Ngadjuri,ngad1257,,,,,Ngadjuri
-ngaiawang,Ngaiawang,lowe1402,,,,,Lower Riverland
-ngamini,Ngamini,ngam1284,,,,,Ngamini
-ngardily,Ngardily,nort2753,,,,,North-western Warlpiri
-ngarigu,Ngarigu,ngar1297,,,,,Ngarigu
-ngarinyman,Ngarinyman,ngar1235,,,,,Ngarinman
-ngarla,Ngarla,ngar1296,,,,,Ngarla
-ngarluma,Ngarluma,ngar1287,,,,,Ngarluma
-ngarrindjeri,Ngarrindjeri,narr1259,,,,,Narrinyeri
-ngawun,Ngawun,ngaw1240,,,,,Ngawun
-ngiyambaa,Ngiyambaa,ngiy1239,,,,,Ngiyambaa
-ngunawal,Ngunawal,ngun1277,,,,,Ngunawal
-nhanta,Nhanta,nhan1238,,,,,Nhanda
-nhirrpi,Nhirrpi,nhir1234,,,,,Nhirrpi
-northernmangarla,Northern Mangarla,mang1383,,,,,Mangala
-northernnyangumarta,Northern Nyangumarta,nort2754,,,,,Northern Coastal Nyangumarta
-nyamal,Nyamal,nyam1271,,,,,Nyamal
-nyangumarta,Nyangumarta,nyan1301,,,,,Nyangumarta
-nyungar,Nyungar,nyun1247,,,,,Nyunga
-paakantyi,Paakantyi,darl1243,,,,,Paakantyi
-pakanh,Pakanh,paka1251,,,,,Pakanha
-pallanganmiddang,Pallanganmiddang,pall1243,,,,,Pallanganmiddang
-panyjima,Panyjima,pany1241,,,,,Panytyima
-parnkala,Parnkala,bang1339,,,,,Banggarla
-payungu,Payungu,bayu1240,,,,,Bayungu
-piangil,Piangil,west2443,,,,,Western Victoria
-pintupiluritja,Pintupi-Luritja,pint1250,,,,,Pintupi-Luritja
-pirriya,Pirriya,pirr1240,,,,,Pirriya
-pitjantjatjara,Pitjantjatjara,pitj1243,,,,,Pitjantjatjara
-pittapitta,Pitta-Pitta,pitt1247,,,,,Pitta Pitta
-rirratjingu,Rirratjingu,rirr1238,,,,,Rirratjingu
-ritharrngu,Ritharrngu,rita1239,,,,,Ritarungo
-southernwalmajarri,Southern Walmajarri,,,,,, 
-thalanyji,Thalanyji,dhal1245,,,,,Dhalandji
-tharrgari,Tharrgari,dhar1247,,,,,Dhargari
-umpila,Umpila,umpi1239,,,,,Umpila
-wajarri,Wajarri,waja1257,,,,,Wajarri
-wakaya,Wakaya,waga1260,,,,,Wagaya
-walmajarribilliluna,WalmajarriBilliluna,,,,,, 
-walmajarrihr,WalmajarriHR,,,,,, 
-walmajarrinw,WalmajarriNW,,,,,, 
-wangkangurru,Wangkangurru,wang1290,,,,,Wangganguru
-wangkatja,Wangkatja,pint1251,,,,,Pintiini
-wangkayutyuru,Wangkayutyuru,wang1289,,,,,Wanggamala
-wangkumara,Wangkumara,ngur1261,,,,,Ngura
-wangkumaramcdwur,WangkumaraMcDWur,,,,,,
-wardandi,Wardandi,ward1248,,,,,Wardandi
-wargamay,Wargamay,warr1255,,,,,Warrgamay
-warlmanpa,Warlmanpa,warl1255,,,,,Warlmanpa
-warlpiri,Warlpiri,warl1254,,,,,Warlpiri
-warluwarra,Warluwarra,warl1256,,,,,Warluwara
-warnman,Warnman,wanm1242,,,,,Wanman
-warriyangga,Warriyangga,wari1262,,,,,Wariyangga
-warumungu,Warumungu,waru1265,,,,,Warumungu
-warungu,Warungu,waru1264,,,,,Warrungo
-wathawurrung,Wathawurrung,wath1238,,,,,Wathawurrung
-wathiwathi,Wathiwathi,wadi1249,,,,,Wadiwadi
-watjuk,Watjuk,waju1234,,,,,Wajuk
-westernarrarnta,Western Arrarnta,west2441,,,,,Western Arrarnta
-wikmungkan,Wik Mungkan,wikm1247,,,,,Wik-Mungkan
-wiradjuri,Wiradjuri,wira1262,,,,,Wiradhuri
-wirangu,Wirangu,wira1265,,,,,Wirangu-Nauo
-woiwurrung,Woiwurrung,woiw1237,,,,,Woiwurrung
-wulguru,Wulguru,wulg1239,,,,,Wulguru
-yabulayabula,Yabula Yabula,yabu1234,,,,,Yabula Yabula
-yagara,Yagara,yaga1262,,,,,Yagara
-yalarnnga,Yalarnnga,yala1262,,,,,Yalarnnga
-yannhangu,Yan-nhangu,yann1237,,,,,Yan-nhangu
-yandruwandha,Yandruwandha,yand1253,,,,,Yandruwandha
-yanyuwa,Yanyuwa,yany1243,,,,,Yanyuwa
-yarluyandi,Yarluyandi,yarl1238,,,,,Yarluyandi
-yawarrawarrka,Yawarrawarrka,yawa1258,,,,,Yawarawarga
-yidiny,Yidiny,yidi1250,,,,,Yidiñ
-yindjibarndi,Yindjibarndi,yind1247,,,,,Yindjibarndi
-yindjilandji,Yindjilandji,yind1248,,,,,Yindjilandji
-yiningay,Yiningay,bidy1243,,,,,Bidyara
-yirandali,Yirandali,yira1239,,,,,Yirandhali
-yortayorta,Yorta Yorta,yort1237,,,,,Yorta Yorta
-yugambeh,Yugambeh,,,,,,
-yulparija,Yulparija,yulp1238,,,,,Yulparitja
-yuwaalaraay,Yuwaalaraay,yuwa1242,,,,,Yuwaalaraay
+ID,Name,Glottocode,Glottolog_Name,ISO639P3code,Macroarea,Family
+adnyamathanha,Adnyamathanha,adny1235,,,,
+aghutharrnggala,Aghu-Tharrnggala,aghu1254,,,,
+alyawarr,Alyawarr,alya1239,,,,
+antekerrepenhe,Antekerrepenhe,ande1247,,,,
+arabana,Arabana,arab1267,,,,
+awabakal,Awabakal,awab1243,,,,
+badimaya,Badimaya,badi1246,,,,
+badjiri,Badjiri,badj1244,,,,
+bandjalang,Bandjalang,band1339,,,,
+batyala,Batyala,kabi1260,,,,
+bidyaragungabula,Bidyara-Gungabula,sout2765,,,,
+bilinarra,Bilinarra,bili1250,,,,
+biri,Biri,biri1256,,,,
+birrpayi,Birrpayi,birr1241,,,,
+bularnu,Bularnu,bula1255,,,,
+bunganditj,Bunganditj,bung1264,,,,
+colac,Colac,cola1237,,,,
+darkinyung,Darkinyung,hawk1239,,,,
+dhangu,Dhangu,dhan1270,,,,
+dharawal,Dharawal,thur1254,,,,
+dharuk,Dharuk,sydn1236,,,,
+dharumbal,Dharumbal,dhar1248,,,,
+dhayyi,Dhayyi,dayi1244,,,,
+dhudhuroa,Dhudhuroa,dhud1236,,,,
+dhurga,Dhurga,dhur1239,,,,
+dhuwal,Dhuwal,dhuw1249,,,,
+dhuwala,Dhuwala,,,,,
+diyari,Diyari,dier1241,,,,
+djabugay,Djabugay,dyaa1242,,,,
+djambarrpuyngu,Djambarrpuyngu,djam1256,,,,
+djapu,Djapu,djap1238,,,,
+djinang,Djinang,djin1253,,,,
+durubul,Durubul,,,,,
+duungidjawu,Duungidjawu,duun1241,,,,
+dyirbal,Dyirbal,dyir1250,,,,
+flindersisland,Flinders Island,flin1247,,,,
+gairi,Gairi,wadj1255,,,,
+gamilaraay,Gamilaraay,gami1243,,,,
+gangulu,Gangulu,gang1268,,,,
+garlali,Garlali,kala1380,,,,
+goorenggooreng,Gooreng Gooreng,gure1255,,,,
+gudjal,Gudjal,gudj1237,,,,
+gumatj,Gumatj,guma1253,,,,
+gumbaynggir,Gumbaynggir,kumb1268,,,,
+gunditjmara,Gunditjmara,gund1249,,,,
+gundungurra,Gundungurra,nort2760,,,,
+gunggari,Gunggari,kung1258,,,,
+gunya,Gunya,guny1241,,,,
+gupapuyngu,Gupapuyngu,gupa1247,,,,
+gurindji,Gurindji,guri1247,,,,
+guuguyimidhirr,Guugu-Yimidhirr,gugu1255,,,,
+guwa,Guwa,guwa1242,,,,
+guyani,Guyani,guya1249,,,,
+iyora,Iyora,sydn1236,,,,
+jaru,Jaru,jaru1254,,,,
+jarumcc,Jaru-McC,,,,,
+jiwarli,Jiwarli,djiw1241,,,,
+jiwarliny,Jiwarliny,walm1241,,,,
+kaanju,Kaanju,kanj1260,,,,
+kalkatungu,Kalkatungu,kalk1246,,,,
+kamilaroi,Kamilaroi,gami1243,,,,
+karajarri,Karajarri,kara1476,,,,
+karajarrinw,KarajarriNW,,,,,
+kariyarra,Kariyarra,kari1304,,,,
+karree,Karree,,,,,
+kartujarra,Kartujarra,kart1247,,,,
+karuwali,Karuwali,karr1236,,,,
+katthang,Katthang,gath1234,,,,
+kaurna,Kaurna,kaur1267,,,,
+keramin,Keramin,nort2756,,,,
+kugunganhcara,Kugu Nganhcara,kuku1280,,,,
+kukatj,Kukatj,guga1239,,,,
+kukatja,Kukatja,kuka1246,,,,
+kukuyalanji,Kuku Yalanji,kuku1273,,,,
+kukuyalanjicurr,KukuYalanjiCurr,,,,,
+kungadutyi,Kungadutyi,,,,,
+kungkari,Kungkari,kuun1236,,,,
+kurnu,Kurnu,kula1275,,,,
+kurrama,Kurrama,kurr1243,,,,
+kurtjar,Kurtjar,gurd1238,,,,
+kuukuyau,Kuuku-Ya’u,kuuk1238,,,,
+linngithigh,Linngithigh,leni1238,,,,
+mabuiag,Mabuiag,kala1377,,,,
+malgana,Malgana,malg1242,,,,
+malngin,Malngin,maln1239,,,,
+malyangapa,Malyangapa,maly1234,,,,
+mangalamck,MangalaMcK,,,,,
+mangalanw,MangalaNW,,,,,
+margany,Margany,marg1253,,,,
+martuwangka,Martu Wangka,mart1256,,,,
+maryriverandbunyabunyacountry,Mary River and Bunya Bunya Country,,,,,
+mathimathi,Mathi-Mathi,madh1244,,,,
+mayikulan,Mayi-Kulan,mayi1236,,,,
+mayikutuna,Mayi-Kutuna,maya1280,,,,
+mayithakurti,Mayi-Thakurti,mayi1234,,,,
+mayiyapi,Mayi-Yapi,mayi1235,,,,
+mbabaram,Mbabaram,mbab1239,,,,
+mbakwithi,Mbakwithi,angu1242,,,,
+minjungbal,Minjungbal,minj1242,,,,
+mirniny,Mirniny,kala1379,,,,
+mithaka,Mithaka,mith1236,,,,
+mountfreelingdiyari,Mount Freeling Diyari,,,,,
+mudburra,Mudburra,mudb1240,,,,
+mudburramcc,Mudburra-McC,,,,,
+muruwari,Muruwari,muru1266,,,,
+narrungga,Narrungga,naru1238,,,,
+nggoimwoi,Ng'goi Mwoi,,,,,
+ngaanyatjarra,Ngaanyatjarra,ngaa1240,,,,
+ngadjumaya,Ngadjumaya,ngad1258,,,,
+ngadjuri,Ngadjuri,ngad1257,,,,
+ngaiawang,Ngaiawang,lowe1402,,,,
+ngamini,Ngamini,ngam1284,,,,
+ngardily,Ngardily,nort2753,,,,
+ngarigu,Ngarigu,ngar1297,,,,
+ngarinyman,Ngarinyman,ngar1235,,,,
+ngarla,Ngarla,ngar1296,,,,
+ngarluma,Ngarluma,ngar1287,,,,
+ngarrindjeri,Ngarrindjeri,narr1259,,,,
+ngawun,Ngawun,ngaw1240,,,,
+ngiyambaa,Ngiyambaa,ngiy1239,,,,
+ngunawal,Ngunawal,ngun1277,,,,
+nhanta,Nhanta,nhan1238,,,,
+nhirrpi,Nhirrpi,nhir1234,,,,
+northernmangarla,Northern Mangarla,mang1383,,,,
+northernnyangumarta,Northern Nyangumarta,nort2754,,,,
+nyamal,Nyamal,nyam1271,,,,
+nyangumarta,Nyangumarta,nyan1301,,,,
+nyungar,Nyungar,nyun1247,,,,
+paakantyi,Paakantyi,darl1243,,,,
+pakanh,Pakanh,paka1251,,,,
+pallanganmiddang,Pallanganmiddang,pall1243,,,,
+panyjima,Panyjima,pany1241,,,,
+parnkala,Parnkala,bang1339,,,,
+payungu,Payungu,bayu1240,,,,
+piangil,Piangil,west2443,,,,
+pintupiluritja,Pintupi-Luritja,pint1250,,,,
+pirriya,Pirriya,pirr1240,,,,
+pitjantjatjara,Pitjantjatjara,pitj1243,,,,
+pittapitta,Pitta-Pitta,pitt1247,,,,
+rirratjingu,Rirratjingu,rirr1238,,,,
+ritharrngu,Ritharrngu,rita1239,,,,
+southernwalmajarri,Southern Walmajarri,,,,,
+thalanyji,Thalanyji,dhal1245,,,,
+tharrgari,Tharrgari,dhar1247,,,,
+umpila,Umpila,umpi1239,,,,
+wajarri,Wajarri,waja1257,,,,
+wakaya,Wakaya,waga1260,,,,
+walmajarribilliluna,WalmajarriBilliluna,,,,,
+walmajarrihr,WalmajarriHR,,,,,
+walmajarrinw,WalmajarriNW,,,,,
+wangkangurru,Wangkangurru,wang1290,,,,
+wangkatja,Wangkatja,pint1251,,,,
+wangkayutyuru,Wangkayutyuru,wang1289,,,,
+wangkumara,Wangkumara,ngur1261,,,,
+wangkumaramcdwur,WangkumaraMcDWur,,,,,
+wardandi,Wardandi,ward1248,,,,
+wargamay,Wargamay,warr1255,,,,
+warlmanpa,Warlmanpa,warl1255,,,,
+warlpiri,Warlpiri,warl1254,,,,
+warluwarra,Warluwarra,warl1256,,,,
+warnman,Warnman,wanm1242,,,,
+warriyangga,Warriyangga,wari1262,,,,
+warumungu,Warumungu,waru1265,,,,
+warungu,Warungu,waru1264,,,,
+wathawurrung,Wathawurrung,wath1238,,,,
+wathiwathi,Wathiwathi,wadi1249,,,,
+watjuk,Watjuk,waju1234,,,,
+westernarrarnta,Western Arrarnta,west2441,,,,
+wikmungkan,Wik Mungkan,wikm1247,,,,
+wiradjuri,Wiradjuri,wira1262,,,,
+wirangu,Wirangu,wira1265,,,,
+woiwurrung,Woiwurrung,woiw1237,,,,
+wulguru,Wulguru,wulg1239,,,,
+yabulayabula,Yabula Yabula,yabu1234,,,,
+yagara,Yagara,yaga1262,,,,
+yalarnnga,Yalarnnga,yala1262,,,,
+yannhangu,Yan-nhangu,yann1237,,,,
+yandruwandha,Yandruwandha,yand1253,,,,
+yanyuwa,Yanyuwa,yany1243,,,,
+yarluyandi,Yarluyandi,yarl1238,,,,
+yawarrawarrka,Yawarrawarrka,yawa1258,,,,
+yidiny,Yidiny,yidi1250,,,,
+yindjibarndi,Yindjibarndi,yind1247,,,,
+yindjilandji,Yindjilandji,yind1248,,,,
+yiningay,Yiningay,bidy1243,,,,
+yirandali,Yirandali,yira1239,,,,
+yortayorta,Yorta Yorta,yort1237,,,,
+yugambeh,Yugambeh,,,,,
+yulparija,Yulparija,yulp1238,,,,
+yuwaalaraay,Yuwaalaraay,yuwa1242,,,,

--- a/cldf/parameters.csv
+++ b/cldf/parameters.csv
@@ -77,7 +77,7 @@ cloud,cloud,1489,CLOUD
 cold,cold,1287,COLD
 come,come,1446,COME
 cook,cook,1100,COOK (SOMETHING)
-coolamon,coolamon,481,DISH
+coolamon,coolamon,1539,BASKET
 corpse,corpse,767,CORPSE
 correcttrue,correct/true,1725,CORRECT (RIGHT)
 count,count,1420,COUNT
@@ -91,7 +91,7 @@ dark,dark,706,DARK
 day,day,1225,DAY (NOT NIGHT)
 deaf,deaf,996,DEAF
 dew,dew,1977,DEW
-diebedead,die/be dead,1494,DIE
+diebedead,die/be dead,2101,BE DEAD OR DIE
 dig,dig,1418,DIG
 diggingstick,digging stick,339,DIGGING STICK
 dingowolf,dingo/wolf,2461,WOLF-LIKE ANIMAL

--- a/cldf/sources.bib
+++ b/cldf/sources.bib
@@ -1,6 +1,6 @@
 @article{Bowern2012,
-    Abstract = {We present the first proposal of detailed internal subgrouping and higher-order structure of the Pama-Nyungan family of Australian languages. Previous work has identified more than twenty- five primary subgroups in the family, with little indication of how these groups might fit together. Some work has assumed that reconstruction of higher nodes in the tree was impossible, either be- cause extensive internal borrowing has obscured more remote relations, or because the languages are not sufficiently well attested (see, for example, Bowern & Koch 2004b, Dixon 1997). With re- gard to the first objection, work by Alpher and Nash (1999) and Bowern and colleagues (2011) shows that loan levels are not high enough to obscure vertical transmission for all but a few lan- guages. New data remove the second objection. Here we use Bayesian phylogenetic inference to show that the Pama-Nyungan tree has a discernible internal subgrouping. We identify four major divisions within the family and discuss the implications of this grouping for future work on the family.},
     Author = {Bowern, Claire and Atkinson, Quentin D.},
+    Abstract = {We present the first proposal of detailed internal subgrouping and higher-order structure of the Pama-Nyungan family of Australian languages. Previous work has identified more than twenty- five primary subgroups in the family, with little indication of how these groups might fit together. Some work has assumed that reconstruction of higher nodes in the tree was impossible, either be- cause extensive internal borrowing has obscured more remote relations, or because the languages are not sufficiently well attested (see, for example, Bowern & Koch 2004b, Dixon 1997). With re- gard to the first objection, work by Alpher and Nash (1999) and Bowern and colleagues (2011) shows that loan levels are not high enough to obscure vertical transmission for all but a few lan- guages. New data remove the second objection. Here we use Bayesian phylogenetic inference to show that the Pama-Nyungan tree has a discernible internal subgrouping. We identify four major divisions within the family and discuss the implications of this grouping for future work on the family.},
     Journal = {Language},
     Pages = {817-845},
     Title = {Computational phylogenetics of the internal structure of Pama-Nguyan},
@@ -10,8 +10,8 @@
 
 @inproceedings{List2014e,
     Author = {List, J.-M. and Prokić, J.},
+    Editor = {Chair), Nicoletta Calzolari (Conference and Choukri, Khalid and Declerck, Thierry and Loftsson, Hrafn and Maegaard, Bente and Mariani, Joseph and Moreno, Asuncion and Odijk, Jan and Piperidis, Stelios},
     Booktitle = {Proceedings of the Ninth International Conference on Language Resources and Evaluation},
-    Editor = {Nicoletta Calzolari (Conference Chair) and Khalid Choukri and Thierry Declerck and Hrafn Loftsson and Bente Maegaard and Joseph Mariani and Asuncion Moreno and Jan Odijk and Stelios Piperidis},
     Pages = {288-294},
     Publisher = {European Language Resources Association (ELRA)},
     Title = {A benchmark database of phonetic alignments in historical linguistics and dialectology.},

--- a/etc/languages.csv
+++ b/etc/languages.csv
@@ -1,191 +1,191 @@
-Name,Glottocode,Glottolog_name
-Adnyamathanha,adny1235,Adnyamathanha
-Aghu-Tharrnggala,aghu1254,Aghu Tharnggalu
-Alyawarr,alya1239,Alyawarr
-Antekerrepenhe,ande1247,Andegerebinha
-Arabana,arab1267,Arabana
-Awabakal,awab1243,Awabakal
-Badimaya,badi1246,Badimaya
-Badjiri,badj1244,Badjiri
-Bandjalang,band1339,Yugambeh-Bandjalang
-Batyala,kabi1260,Kabikabi
-Bidyara-Gungabula,sout2765,Southern Maric
-Bilinarra,bili1250,Bilinara
-Biri,biri1256,Biri
-Birrpayi,birr1241,Birrpayi
-Bularnu,bula1255,Bularnu
-Bunganditj,bung1264,Bunganditj
-Colac,cola1237,Colac
-Darkinyung,hawk1239,Hawkesbury
-Dhangu,dhan1270,Dhangu
-Dharawal,thur1254,Thurawal
-Dharuk,sydn1236,Sydney
-Dharumbal,dhar1248,Dharumbal
-Dhayyi,dayi1244,Dayi
-Dhudhuroa,dhud1236,Dhudhuroa
-Dhurga,dhur1239,Dhurga
-Dhuwal,dhuw1249,Dhuwal
-Dhuwala,,
-Diyari,dier1241,Dieri
-Djabugay,dyaa1242,Dyaabugay
-Djambarrpuyngu,djam1256,Djambarrpuyngu
-Djapu,djap1238,Djapu
-Djinang,djin1253,Djinang
-Durubul,,
-Duungidjawu,duun1241,Duungidjawu
-Dyirbal,dyir1250,Dyirbal
-Flinders Island,flin1247,Flinders Island
-Gairi,wadj1255,Wadjigu
-Gamilaraay,gami1243,Gamilaraay
-Gangulu,gang1268,Gangulu
-Garlali,kala1380,Kalali
-Gooreng Gooreng,gure1255,Gureng Gureng
-Gudjal,gudj1237,Gudjal
-Gumatj,guma1253,Gumatj
-Gumbaynggir,kumb1268,Kumbainggar
-Gunditjmara,gund1249,Gunditjmara
-Gundungurra,nort2760,Northern Inland Yui
-Gunggari,kung1258,Kunggari
-Gunya,guny1241,Gunya
-Gupapuyngu,gupa1247,Gupapuyngu
-Gurindji,guri1247,Gurindji
-Guugu-Yimidhirr,gugu1255,Guugu Yimidhirr
-Guwa,guwa1242,Guwa
-Guyani,guya1249,Guyani
-Iyora,sydn1236,Sydney
-Jaru,jaru1254,Jaru
-Jaru-McC,,
-Jiwarli,djiw1241,Djiwarli
-Jiwarliny,walm1241,Walmajarri
-Kaanju,kanj1260,Kanju
-Kalkatungu,kalk1246,Kalkutung
-Kamilaroi,gami1243,Gamilaraay
-Karajarri,kara1476,Karadjeri
-KarajarriNW,,
-Kariyarra,kari1304,Kariyarra
-Karree,,
-Kartujarra,kart1247,Kartujarra
-Karuwali,karr1236,Karruwali
-Katthang,gath1234,Gathang
-Kaurna,kaur1267,Kaurna
-Keramin,nort2756,Northern Sunraysia
-Kugu Nganhcara,kuku1280,Kuku-Uwan
-Kukatj,guga1239,Gugadj
-Kukatja,kuka1246,Kukatja
-Kuku Yalanji,kuku1273,Kuku-Yalanji
-KukuYalanjiCurr,,
-Kungadutyi,,
-Kungkari,kuun1236,Kuungkari of Barcoo River
-Kurnu,kula1275,Kula (Australia)
-Kurrama,kurr1243,Kurrama
-Kurtjar,gurd1238,Gurdjar
-Kuuku-Ya’u,kuuk1238,Kuuku-Ya'u
-Linngithigh,leni1238,Leningitij
-Mabuiag,kala1377,Kala Lagaw Ya
-Malgana,malg1242,Malgana
-Malngin,maln1239,Malngin
-Malyangapa,maly1234,Malyangapa
-MangalaMcK,,
-MangalaNW,,
-Margany,marg1253,Margany
-Martu Wangka,mart1256,Martu Wangka
-Mary River and Bunya Bunya Country,,
-Mathi-Mathi,madh1244,Madhi Madhi
-Mayi-Kulan,mayi1236,Mayi-Kulan
-Mayi-Kutuna,maya1280,Mayaguduna
-Mayi-Thakurti,mayi1234,Mayi-Thakurti
-Mayi-Yapi,mayi1235,Mayi-Yapi
-Mbabaram,mbab1239,Mbabaram
-Mbakwithi,angu1242,Anguthimri
-Minjungbal,minj1242,Minjungbal
-Mirniny,kala1379,Kalarko
-Mithaka,mith1236,Mithaka
-Mount Freeling Diyari,,
-Mudburra,mudb1240,Mudburra
-Mudburra-McC,,
-Muruwari,muru1266,Muruwari
-Narrungga,naru1238,Narungga
-Ng'goi Mwoi,,
-Ngaanyatjarra,ngaa1240,Ngaanyatjarra
-Ngadjumaya,ngad1258,Ngadjunmaya
-Ngadjuri,ngad1257,Ngadjuri
-Ngaiawang,lowe1402,Lower Riverland
-Ngamini,ngam1284,Ngamini
-Ngardily,nort2753,North-western Warlpiri
-Ngarigu,ngar1297,Ngarigu
-Ngarinyman,ngar1235,Ngarinman
-Ngarla,ngar1296,Ngarla
-Ngarluma,ngar1287,Ngarluma
-Ngarrindjeri,narr1259,Narrinyeri
-Ngawun,ngaw1240,Ngawun
-Ngiyambaa,ngiy1239,Ngiyambaa
-Ngunawal,ngun1277,Ngunawal
-Nhanta,nhan1238,Nhanda
-Nhirrpi,nhir1234,Nhirrpi
-Northern Mangarla,mang1383,Mangala
-Northern Nyangumarta,nort2754,Northern Coastal Nyangumarta
-Nyamal,nyam1271,Nyamal
-Nyangumarta,nyan1301,Nyangumarta
-Nyungar,nyun1247,Nyunga
-Paakantyi,darl1243,Paakantyi
-Pakanh,paka1251,Pakanha
-Pallanganmiddang,pall1243,Pallanganmiddang
-Panyjima,pany1241,Panytyima
-Parnkala,bang1339,Banggarla
-Payungu,bayu1240,Bayungu
-Piangil,west2443,Western Victoria
-Pintupi-Luritja,pint1250,Pintupi-Luritja
-Pirriya,pirr1240,Pirriya
-Pitjantjatjara,pitj1243,Pitjantjatjara
-Pitta-Pitta,pitt1247,Pitta Pitta
-Rirratjingu,rirr1238,Rirratjingu
-Ritharrngu,rita1239,Ritarungo
-Southern Walmajarri,, 
-Thalanyji,dhal1245,Dhalandji
-Tharrgari,dhar1247,Dhargari
-Umpila,umpi1239,Umpila
-Wajarri,waja1257,Wajarri
-Wakaya,waga1260,Wagaya
-WalmajarriBilliluna,, 
-WalmajarriHR,, 
-WalmajarriNW,, 
-Wangkangurru,wang1290,Wangganguru
-Wangkatja,pint1251,Pintiini
-Wangkayutyuru,wang1289,Wanggamala
-Wangkumara,ngur1261,Ngura
-WangkumaraMcDWur,,
-Wardandi,ward1248,Wardandi
-Wargamay,warr1255,Warrgamay
-Warlmanpa,warl1255,Warlmanpa
-Warlpiri,warl1254,Warlpiri
-Warluwarra,warl1256,Warluwara
-Warnman,wanm1242,Wanman
-Warriyangga,wari1262,Wariyangga
-Warumungu,waru1265,Warumungu
-Warungu,waru1264,Warrungo
-Wathawurrung,wath1238,Wathawurrung
-Wathiwathi,wadi1249,Wadiwadi
-Watjuk,waju1234,Wajuk
-Western Arrarnta,west2441,Western Arrarnta
-Wik Mungkan,wikm1247,Wik-Mungkan
-Wiradjuri,wira1262,Wiradhuri
-Wirangu,wira1265,Wirangu-Nauo
-Woiwurrung,woiw1237,Woiwurrung
-Wulguru,wulg1239,Wulguru
-Yabula Yabula,yabu1234,Yabula Yabula
-Yagara,yaga1262,Yagara
-Yalarnnga,yala1262,Yalarnnga
-Yan-nhangu,yann1237,Yan-nhangu
-Yandruwandha,yand1253,Yandruwandha
-Yanyuwa,yany1243,Yanyuwa
-Yarluyandi,yarl1238,Yarluyandi
-Yawarrawarrka,yawa1258,Yawarawarga
-Yidiny,yidi1250,Yidiñ
-Yindjibarndi,yind1247,Yindjibarndi
-Yindjilandji,yind1248,Yindjilandji
-Yiningay,bidy1243,Bidyara
-Yirandali,yira1239,Yirandhali
-Yorta Yorta,yort1237,Yorta Yorta
-Yugambeh,,
-Yulparija,yulp1238,Yulparitja
-Yuwaalaraay,yuwa1242,Yuwaalaraay
+ID,Name,Glottocode
+,Adnyamathanha,adny1235
+,Aghu-Tharrnggala,aghu1254
+,Alyawarr,alya1239
+,Antekerrepenhe,ande1247
+,Arabana,arab1267
+,Awabakal,awab1243
+,Badimaya,badi1246
+,Badjiri,badj1244
+,Bandjalang,band1339
+,Batyala,kabi1260
+,Bidyara-Gungabula,sout2765
+,Bilinarra,bili1250
+,Biri,biri1256
+,Birrpayi,birr1241
+,Bularnu,bula1255
+,Bunganditj,bung1264
+,Colac,cola1237
+,Darkinyung,hawk1239
+,Dhangu,dhan1270
+,Dharawal,thur1254
+,Dharuk,sydn1236
+,Dharumbal,dhar1248
+,Dhayyi,dayi1244
+,Dhudhuroa,dhud1236
+,Dhurga,dhur1239
+,Dhuwal,dhuw1249
+,Dhuwala,
+,Diyari,dier1241
+,Djabugay,dyaa1242
+,Djambarrpuyngu,djam1256
+,Djapu,djap1238
+,Djinang,djin1253
+,Durubul,
+,Duungidjawu,duun1241
+,Dyirbal,dyir1250
+,Flinders Island,flin1247
+,Gairi,wadj1255
+,Gamilaraay,gami1243
+,Gangulu,gang1268
+,Garlali,kala1380
+,Gooreng Gooreng,gure1255
+,Gudjal,gudj1237
+,Gumatj,guma1253
+,Gumbaynggir,kumb1268
+,Gunditjmara,gund1249
+,Gundungurra,nort2760
+,Gunggari,kung1258
+,Gunya,guny1241
+,Gupapuyngu,gupa1247
+,Gurindji,guri1247
+,Guugu-Yimidhirr,gugu1255
+,Guwa,guwa1242
+,Guyani,guya1249
+,Iyora,sydn1236
+,Jaru,jaru1254
+,Jaru-McC,
+,Jiwarli,djiw1241
+,Jiwarliny,walm1241
+,Kaanju,kanj1260
+,Kalkatungu,kalk1246
+,Kamilaroi,gami1243
+,Karajarri,kara1476
+,KarajarriNW,
+,Kariyarra,kari1304
+,Karree,
+,Kartujarra,kart1247
+,Karuwali,karr1236
+,Katthang,gath1234
+,Kaurna,kaur1267
+,Keramin,nort2756
+,Kugu Nganhcara,kuku1280
+,Kukatj,guga1239
+,Kukatja,kuka1246
+,Kuku Yalanji,kuku1273
+,KukuYalanjiCurr,
+,Kungadutyi,
+,Kungkari,kuun1236
+,Kurnu,kula1275
+,Kurrama,kurr1243
+,Kurtjar,gurd1238
+,Kuuku-Ya’u,kuuk1238
+,Linngithigh,leni1238
+,Mabuiag,kala1377
+,Malgana,malg1242
+,Malngin,maln1239
+,Malyangapa,maly1234
+,MangalaMcK,
+,MangalaNW,
+,Margany,marg1253
+,Martu Wangka,mart1256
+,Mary River and Bunya Bunya Country,
+,Mathi-Mathi,madh1244
+,Mayi-Kulan,mayi1236
+,Mayi-Kutuna,maya1280
+,Mayi-Thakurti,mayi1234
+,Mayi-Yapi,mayi1235
+,Mbabaram,mbab1239
+,Mbakwithi,angu1242
+,Minjungbal,minj1242
+,Mirniny,kala1379
+,Mithaka,mith1236
+,Mount Freeling Diyari,
+,Mudburra,mudb1240
+,Mudburra-McC,
+,Muruwari,muru1266
+,Narrungga,naru1238
+,Ng'goi Mwoi,
+,Ngaanyatjarra,ngaa1240
+,Ngadjumaya,ngad1258
+,Ngadjuri,ngad1257
+,Ngaiawang,lowe1402
+,Ngamini,ngam1284
+,Ngardily,nort2753
+,Ngarigu,ngar1297
+,Ngarinyman,ngar1235
+,Ngarla,ngar1296
+,Ngarluma,ngar1287
+,Ngarrindjeri,narr1259
+,Ngawun,ngaw1240
+,Ngiyambaa,ngiy1239
+,Ngunawal,ngun1277
+,Nhanta,nhan1238
+,Nhirrpi,nhir1234
+,Northern Mangarla,mang1383
+,Northern Nyangumarta,nort2754
+,Nyamal,nyam1271
+,Nyangumarta,nyan1301
+,Nyungar,nyun1247
+,Paakantyi,darl1243
+,Pakanh,paka1251
+,Pallanganmiddang,pall1243
+,Panyjima,pany1241
+,Parnkala,bang1339
+,Payungu,bayu1240
+,Piangil,west2443
+,Pintupi-Luritja,pint1250
+,Pirriya,pirr1240
+,Pitjantjatjara,pitj1243
+,Pitta-Pitta,pitt1247
+,Rirratjingu,rirr1238
+,Ritharrngu,rita1239
+,Southern Walmajarri,
+,Thalanyji,dhal1245
+,Tharrgari,dhar1247
+,Umpila,umpi1239
+,Wajarri,waja1257
+,Wakaya,waga1260
+,WalmajarriBilliluna,
+,WalmajarriHR,
+,WalmajarriNW,
+,Wangkangurru,wang1290
+,Wangkatja,pint1251
+,Wangkayutyuru,wang1289
+,Wangkumara,ngur1261
+,WangkumaraMcDWur,
+,Wardandi,ward1248
+,Wargamay,warr1255
+,Warlmanpa,warl1255
+,Warlpiri,warl1254
+,Warluwarra,warl1256
+,Warnman,wanm1242
+,Warriyangga,wari1262
+,Warumungu,waru1265
+,Warungu,waru1264
+,Wathawurrung,wath1238
+,Wathiwathi,wadi1249
+,Watjuk,waju1234
+,Western Arrarnta,west2441
+,Wik Mungkan,wikm1247
+,Wiradjuri,wira1262
+,Wirangu,wira1265
+,Woiwurrung,woiw1237
+,Wulguru,wulg1239
+,Yabula Yabula,yabu1234
+,Yagara,yaga1262
+,Yalarnnga,yala1262
+,Yan-nhangu,yann1237
+,Yandruwandha,yand1253
+,Yanyuwa,yany1243
+,Yarluyandi,yarl1238
+,Yawarrawarrka,yawa1258
+,Yidiny,yidi1250
+,Yindjibarndi,yind1247
+,Yindjilandji,yind1248
+,Yiningay,bidy1243
+,Yirandali,yira1239
+,Yorta Yorta,yort1237
+,Yugambeh,
+,Yulparija,yulp1238
+,Yuwaalaraay,yuwa1242

--- a/lexibank_bowernpny.py
+++ b/lexibank_bowernpny.py
@@ -9,13 +9,12 @@ from clldutils.misc import slug
 import attr
 
 from pylexibank.dataset import Metadata
-from pylexibank.dataset import Dataset as BaseDataset, Language as BaseLanguage
+from pylexibank.dataset import Dataset as BaseDataset
 from pylexibank.util import getEvoBibAsBibtex
 
 class Dataset(BaseDataset):
     dir = Path(__file__).parent
     id = 'bowernpny'
-    language_class = BaseLanguage
 
     def cmd_install(self, **kw):
         # Please note that we are removing asterisks from Bowern et al. data, used to

--- a/lexibank_bowernpny.py
+++ b/lexibank_bowernpny.py
@@ -12,16 +12,10 @@ from pylexibank.dataset import Metadata
 from pylexibank.dataset import Dataset as BaseDataset, Language as BaseLanguage
 from pylexibank.util import getEvoBibAsBibtex
 
-
-@attr.s
-class Language(BaseLanguage):
-    Glottolog_name = attr.ib(default=None)
-
-
 class Dataset(BaseDataset):
     dir = Path(__file__).parent
     id = 'bowernpny'
-    language_class = Language
+    language_class = BaseLanguage
 
     def cmd_install(self, **kw):
         # Please note that we are removing asterisks from Bowern et al. data, used to


### PR DESCRIPTION
The code in `master` is currently failing for database loading with the most recent version of pylexibank. This is due to the new organization of `pylexibank.dataset`, in particular its `Language` class -- in short, given that we have a `Glottolog_Name` in `etc/languages.csv`, we end up with  duplicated column names (`makecldf` is not failing because, unlike SQL, it uses case-sensitive dictionary keys -- maybe we should always lower them, catching potential db problems in advance?).

This commit removes the `Glottolog_Name` from `etc/languages.csv` (which is superfluous and in at least one case outdated, as there have been changes in Glottolog) and removes the custom `Language` class (which was only used to carry over that name).